### PR TITLE
Don't use .babelrc in tests

### DIFF
--- a/test/fixtures/basic/expected.js
+++ b/test/fixtures/basic/expected.js
@@ -1,4 +1,2 @@
-"use strict";
-
 "use helloworld";
 hiThere();

--- a/test/index.js
+++ b/test/index.js
@@ -28,6 +28,7 @@ function runTests() {
 function runTest(dir) {
 	var exitCode = 0;
 	var output = babel.transformFileSync(dir.path + '/actual.js', {
+		babelrc: false,
 		plugins: [pluginPath]
 	});
 


### PR DESCRIPTION
This makes the fixtures simpler, as well as independent of the Babel
configuration used to develop the plugin itself.